### PR TITLE
replace all os.system() by subprocess.run()

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ Repo paths are saved in `$XDG_CONFIG_HOME/gita/repo_path` (most likely `~/.confi
 
 The delegated git sub-commands are of two forms
 
-- `gita <subcommand> <repo-name(s)>` with required repo name(s) input
-- `gita <subcommand> [repo-name(s)]` with optional input. And no input means
-  apply the subcommand to all repos.
+- `gita <sub-command> <repo-name(s)>` with required repo name(s) input
+- `gita <sub-command> [repo-name(s)]` with optional input. And no input means
+  all repos.
 
 By default, only `fetch` and `pull` take optional input.
-Subcommands with required input include `branch`, `clean`, `diff`, `difftool`,
+Sub-commands with required input include `branch`, `clean`, `diff`, `difftool`,
 `log`, `merge`, `patch`, `push`, `rebase`, `reflog`, `remote`, `stat`, and `status`.
 
 Delegation details are specified in
@@ -152,6 +152,5 @@ To run tests locally, simply `pytest`.
 
 I haven't tried them but I heard good things about them.
 
-* [myrepos](https://myrepos.branchable.com/)
-* [repo](https://source.android.com/setup/develop/repo)
-
+- [myrepos](https://myrepos.branchable.com/)
+- [repo](https://source.android.com/setup/develop/repo)

--- a/gita/utils.py
+++ b/gita/utils.py
@@ -94,13 +94,16 @@ def get_head(path: str) -> str:
         return os.path.basename(f.read()).rstrip()
 
 
-def has_remote() -> bool:
+def run_quiet_diff(args: List[str]) -> bool:
     """
-    Return True if remote branch exists. It should be run inside the repo.
+    Return the return code of git diff `args` in quiet mode
     """
+    cmd = ['git', 'diff', '--quiet'] + args
     result = subprocess.run(
-        'git diff --quiet @{u} @{0}'.split(), stderr=subprocess.PIPE)
-    return not bool(result.stderr)
+        cmd,
+        stderr=subprocess.PIPE,
+    )
+    return result.returncode
 
 
 def has_untracked() -> bool:
@@ -130,13 +133,12 @@ def exec_git(path: str, cmd: List[str]):
     """
     Execute git `cmd` in the `path` directory
     """
-    os.chdir(path)
     # FIXME: I forgot why I check remote here, but it disables git command
     #        execution if the branch has no remote. Maybe this check is still
     #        needed for the commands not in the yml file?
     # if has_remote():
     #    os.system('git ' + cmd)
-    subprocess.run( ['git'] + cmd)
+    subprocess.run(['git'] + cmd, cwd=path)
 
 
 def get_common_commit() -> str:
@@ -147,7 +149,7 @@ def get_common_commit() -> str:
         'git merge-base @{0} @{u}'.split(),
         stdout=subprocess.PIPE,
         universal_newlines=True)
-    return result.stdout
+    return result.stdout.strip()
 
 
 def _get_repo_status(path: str) -> Tuple[str]:
@@ -155,16 +157,18 @@ def _get_repo_status(path: str) -> Tuple[str]:
     Return the status of one repo
     """
     os.chdir(path)
-    dirty = '*' if os.system('git diff --quiet') else ''
-    staged = '+' if os.system('git diff --cached --quiet') else ''
+    dirty = '*' if run_quiet_diff([]) else ''
+    staged = '+' if run_quiet_diff(['--cached']) else ''
     untracked = '_' if has_untracked() else ''
 
-    if has_remote():
-        if os.system('git diff --quiet @{u} @{0}'):
+    diff_returncode = run_quiet_diff(['@{u}', '@{0}'])
+    has_remote = diff_returncode != 128
+    if has_remote:
+        if diff_returncode == 1:
             common_commit = get_common_commit()
-            outdated = os.system('git diff --quiet @{u} ' + common_commit)
+            outdated = run_quiet_diff(['@{u}', common_commit])
             if outdated:
-                diverged = os.system('git diff --quiet @{0} ' + common_commit)
+                diverged = run_quiet_diff(['@{0}', common_commit])
                 color = Color.red if diverged else Color.yellow
             else:  # local is ahead of remote
                 color = Color.purple

--- a/gita/utils.py
+++ b/gita/utils.py
@@ -162,20 +162,20 @@ def _get_repo_status(path: str) -> Tuple[str]:
     untracked = '_' if has_untracked() else ''
 
     diff_returncode = run_quiet_diff(['@{u}', '@{0}'])
-    has_remote = diff_returncode != 128
-    if has_remote:
-        if diff_returncode == 1:
-            common_commit = get_common_commit()
-            outdated = run_quiet_diff(['@{u}', common_commit])
-            if outdated:
-                diverged = run_quiet_diff(['@{0}', common_commit])
-                color = Color.red if diverged else Color.yellow
-            else:  # local is ahead of remote
-                color = Color.purple
-        else:  # remote == local
-            color = Color.green
-    else:  # no remote
+    has_no_remote = diff_returncode == 128
+    has_no_diff = diff_returncode == 0
+    if has_no_remote:
         color = Color.white
+    elif has_no_diff:
+        color = Color.green
+    else:
+        common_commit = get_common_commit()
+        outdated = run_quiet_diff(['@{u}', common_commit])
+        if outdated:
+            diverged = run_quiet_diff(['@{0}', common_commit])
+            color = Color.red if diverged else Color.yellow
+        else:  # local is ahead of remote
+            color = Color.purple
     return dirty, staged, untracked, color
 
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md') as f:
 setup(
     name='gita',
     packages=['gita'],
-    version='0.7.3',
+    version='0.7.4',
     description='Manage multiple git repos',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -63,19 +63,16 @@ def test_not_add():
     __main__.main(['add', '/home/some/repo/'])
 
 
-@patch('gita.utils.has_remote', return_value=True)
 @patch(
     'gita.utils.get_repos', return_value={
         'repo1': '/a/bc',
         'repo2': '/d/efg'
     })
-@patch('os.chdir')
 @patch('subprocess.run')
-def test_fetch(mock_run, mock_chdir, *_):
+def test_fetch(mock_run, *_):
     __main__.main(['fetch'])
-    mock_chdir.assert_any_call('/a/bc')
-    mock_chdir.assert_any_call('/d/efg')
-    mock_run.assert_any_call(['git', 'fetch'])
+    mock_run.assert_any_call(['git', 'fetch'], cwd='/d/efg')
+    mock_run.assert_any_call(['git', 'fetch'], cwd='/a/bc')
     assert mock_run.call_count == 2
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,22 +5,20 @@ from gita import utils
 from conftest import PATH_FNAME, PATH_FNAME_EMPTY, PATH_FNAME_CLASH
 
 
-@pytest.mark.parametrize('test_input, has_remote, expected', [
+@pytest.mark.parametrize('test_input, diff_return, expected', [
     ({
         'abc': '/root/repo/'
     }, True, 'abc \x1b[31mrepo *+_  \x1b[0m msg'),
     ({
         'repo': '/root/repo2/'
-    }, False, 'repo \x1b[37mrepo *+_  \x1b[0m msg'),
+    }, False, 'repo \x1b[32mrepo _    \x1b[0m msg'),
 ])
-def test_describe(test_input, has_remote, expected, monkeypatch):
+def test_describe(test_input, diff_return, expected, monkeypatch):
     monkeypatch.setattr(utils, 'get_head', lambda x: 'repo')
-    monkeypatch.setattr(utils, 'has_remote', lambda: has_remote)
+    monkeypatch.setattr(utils, 'run_quiet_diff', lambda _: diff_return)
     monkeypatch.setattr(utils, 'get_commit_msg', lambda: "msg")
     monkeypatch.setattr(utils, 'has_untracked', lambda: True)
     monkeypatch.setattr('os.chdir', lambda x: None)
-    # Returns of os.system determine the repo status
-    monkeypatch.setattr('os.system', lambda x: True)
     print('expected: ', repr(expected))
     print('got:      ', repr(next(utils.describe(test_input))))
     assert expected == next(utils.describe(test_input))


### PR DESCRIPTION
This commit should improves the speed of `gita ls` since

- it reduces redundant calls
- `subproccess.run()` copies the process whereas `os.system()` copies the shell

#22 may be even less important