### PR TITLE
Prepend repo when printing output

### DIFF
--- a/gita/__main__.py
+++ b/gita/__main__.py
@@ -87,7 +87,7 @@ def f_git_cmd(args: argparse.Namespace):
         # Here we shut off any user input in the async execution, and re-run
         # the failed ones synchronously.
         errors = utils.exec_async_tasks(
-            utils.run_async(path, cmds) for path in repos.values())
+            utils.run_async(repo_name, path, cmds) for repo_name, path in repos.items())
         for path in errors:
             if path:
                 print(path)

--- a/gita/utils.py
+++ b/gita/utils.py
@@ -108,7 +108,7 @@ def add_repos(repos: Dict[str, str], new_paths: List[str]):
         print('No new repos found!')
 
 
-async def run_async(path: str, cmds: List[str]) -> Union[None, str]:
+async def run_async(repo_name: str, path: str, cmds: List[str]) -> Union[None, str]:
     """
     Run `cmds` asynchronously in `path` directory. Return the `path` if
     execution fails.
@@ -121,12 +121,22 @@ async def run_async(path: str, cmds: List[str]) -> Union[None, str]:
         start_new_session=True,
         cwd=path)
     stdout, stderr = await process.communicate()
-    stdout and print(stdout.decode())
-    stderr and print(stderr.decode())
+    for pipe in (stdout, stderr):
+        if pipe:
+            print(format_output(pipe.decode(), f'{repo_name}: '))
     # The existence of stderr is not good indicator since git sometimes write
     # to stderr even if the execution is successful, e.g. git fetch
     if process.returncode != 0:
         return path
+
+
+def format_output(output: str, prefix: str):
+    """
+    Prepends every line in output with the given prefix.
+
+    NOTE: Not tested on Windows where the output of git may not print '\n' and so this might fail
+    """
+    return ''.join([f'{prefix}{line}' for line in output.splitlines(keepends=True)])
 
 
 def exec_async_tasks(tasks: List[Coroutine]) -> List[Union[None, str]]:

--- a/gita/utils.py
+++ b/gita/utils.py
@@ -130,13 +130,11 @@ async def run_async(repo_name: str, path: str, cmds: List[str]) -> Union[None, s
         return path
 
 
-def format_output(output: str, prefix: str):
+def format_output(s: str, prefix: str):
     """
-    Prepends every line in output with the given prefix.
-
-    NOTE: Not tested on Windows where the output of git may not print '\n' and so this might fail
+    Prepends every line in given string with the given prefix.
     """
-    return ''.join([f'{prefix}{line}' for line in output.splitlines(keepends=True)])
+    return ''.join([f'{prefix}{line}' for line in s.splitlines(keepends=True)])
 
 
 def exec_async_tasks(tasks: List[Coroutine]) -> List[Union[None, str]]:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md') as f:
 setup(
     name='gita',
     packages=['gita'],
-    version='0.10.1',
+    version='0.10.2',
     license='MIT',
     description='Manage multiple git repos',
     long_description=long_description,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -110,8 +110,8 @@ def test_async_fetch(*_):
     assert mock_run.call_count == 2
     cmds = ['git', 'fetch']
     # print(mock_run.call_args_list)
-    mock_run.assert_any_call('/a/bc', cmds)
-    mock_run.assert_any_call('/d/efg', cmds)
+    mock_run.assert_any_call('repo1', '/a/bc', cmds)
+    mock_run.assert_any_call('repo2', '/d/efg', cmds)
 
 
 @pytest.mark.parametrize('input', [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -90,7 +90,7 @@ def test_rename_repo(mock_write):
 
 def test_async_output(capfd):
     tasks = [
-        utils.run_async('.', [
+        utils.run_async('myrepo', '.', [
             'python3', '-c',
             f"print({i});import time; time.sleep({i});print({i})"
         ]) for i in range(4)
@@ -103,4 +103,4 @@ def test_async_output(capfd):
 
     out, err = capfd.readouterr()
     assert err == ''
-    assert out == "0\n0\n\n1\n1\n\n2\n2\n\n3\n3\n\n"
+    assert out == 'myrepo: 0\nmyrepo: 0\n\nmyrepo: 1\nmyrepo: 1\n\nmyrepo: 2\nmyrepo: 2\n\nmyrepo: 3\nmyrepo: 3\n\n'


### PR DESCRIPTION
Output of `gita super status` now looks like:

```
my-app: On branch master
my-app: Changes to be committed:
my-app:   (use "git reset HEAD <file>..." to unstage)
etc...
pycommon: On branch master
pycommon: Your branch is up to date with 'origin/master'.
pycommon: 
pycommon: nothing to commit, working tree clean
pycommon: 
```

It's an improvement