### PR TITLE
[Feature for #118] Creates group->remove, to remove repo(s) from a group

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The bookkeeping sub-commands are
 - `gita freeze`: print information of all repos such as URL, name, and path.
 - `gita group`: group sub-command
     - `gita group add <repo-name(s)> -n <group-name>`: add repo(s) to a new group or existing group
+    - `gita group rmrepo <repo-name(s)> -n <group-name>`: remove repo(s) from existing group
     - `gita group [ll]`: display existing groups with repos
     - `gita group ls`: display existing group names
     - `gita group rename <group-name> <new-name>`: change group name

--- a/gita/__main__.py
+++ b/gita/__main__.py
@@ -141,13 +141,14 @@ def f_group(args: argparse.Namespace):
             utils.write_to_groups_file(groups, 'w')
         else:
             utils.write_to_groups_file({gname: sorted(args.to_group)}, 'a+')
-    elif cmd == 'remove':
+    elif cmd == 'rmrepo':
         gname = args.gname
         if gname in groups:
-            gname_repos = set(groups[gname])
             for repo in args.from_group:
-                gname_repos.discard(repo)
-            groups[gname] = sorted(gname_repos)
+                try:
+                    groups[gname].remove(repo)
+                except ValueError as e:
+                    pass
             utils.write_to_groups_file(groups, 'w')
 
 
@@ -371,13 +372,13 @@ def main(argv=None):
                     metavar='group-name',
                     required=True,
                     help="group name")
-    pg_remove = group_cmds.add_parser('remove', description='remove repo(s) from a group.')
-    pg_remove.add_argument('from_group',
+    pg_rmrepo = group_cmds.add_parser('rmrepo', description='remove repo(s) from a group.')
+    pg_rmrepo.add_argument('from_group',
                     nargs='+',
                     metavar='repo',
                     choices=utils.get_repos(),
                     help="repo(s) to be removed from the group")
-    pg_remove.add_argument('-n', '--name',
+    pg_rmrepo.add_argument('-n', '--name',
                     dest='gname',
                     metavar='group-name',
                     required=True,

--- a/gita/__main__.py
+++ b/gita/__main__.py
@@ -141,6 +141,14 @@ def f_group(args: argparse.Namespace):
             utils.write_to_groups_file(groups, 'w')
         else:
             utils.write_to_groups_file({gname: sorted(args.to_group)}, 'a+')
+    elif cmd == 'remove':
+        gname = args.gname
+        if gname in groups:
+            gname_repos = set(groups[gname])
+            for repo in args.from_group:
+                gname_repos.discard(repo)
+            groups[gname] = sorted(gname_repos)
+            utils.write_to_groups_file(groups, 'w')
 
 
 def f_context(args: argparse.Namespace):
@@ -359,6 +367,17 @@ def main(argv=None):
                     choices=utils.get_repos(),
                     help="repo(s) to be grouped")
     pg_add.add_argument('-n', '--name',
+                    dest='gname',
+                    metavar='group-name',
+                    required=True,
+                    help="group name")
+    pg_remove = group_cmds.add_parser('remove', description='remove repo(s) from a group.')
+    pg_remove.add_argument('from_group',
+                    nargs='+',
+                    metavar='repo',
+                    choices=utils.get_repos(),
+                    help="repo(s) to be removed from the group")
+    pg_remove.add_argument('-n', '--name',
                     dest='gname',
                     metavar='group-name',
                     required=True,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', encoding='utf-8') as f:
 setup(
     name='gita',
     packages=['gita'],
-    version='0.12.4',
+    version='0.12.5',
     license='MIT',
     description='Manage multiple git repos with sanity',
     long_description=long_description,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -283,6 +283,19 @@ class TestGroupCmd:
         mock_write.assert_called_once_with(
                 {'xx': ['a', 'b', 'c'], 'yy': ['a', 'c', 'd']}, 'w')
 
+    @patch('gita.utils.get_repos', return_value={'a': '', 'b': '', 'c': '', 'd': ''})
+    @patch('gita.common.get_config_fname', return_value=GROUP_FNAME)
+    @patch('gita.utils.write_to_groups_file')
+    def testRmRepo(self, mock_write, *_):
+        args = argparse.Namespace()
+        args.from_group = ['a', 'c']
+        args.group_cmd = 'rmrepo'
+        args.gname = 'xx'
+        utils.get_groups.cache_clear()
+        __main__.f_group(args)
+        mock_write.assert_called_once_with(
+                {'xx': ['b'], 'yy': ['a', 'c', 'd']}, 'w')
+
 
 @patch('gita.utils.is_git', return_value=True)
 @patch('gita.common.get_config_fname', return_value=PATH_FNAME)


### PR DESCRIPTION
Create group subcommand 'remove', to remove a repo or list of repos from an existing group.
If group or repo doesn't exist, does nothing.
Does not remote the repo from gita repos file.

https://github.com/nosarthur/gita/issues/118