### PR TITLE
Added `shell=True` to `shell` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,9 +171,7 @@ Here `repo-name(s)` or `group-name(s)` are optional, and their absence means all
 For example,
 
 - `gita shell ll` lists contents for all repos
-- `gita shell repo1 "mkdir docs"` create a new directory `docs` in repo1
-
-Note that shell commands containing spaces must be wrapped by quotes to be correctly interpreted.
+- `gita shell repo1 mkdir docs` create a new directory `docs` in repo1
 
 ## <a name='custom'></a> Customization
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,9 @@ Here `repo-name(s)` or `group-name(s)` are optional, and their absence means all
 For example,
 
 - `gita shell ll` lists contents for all repos
-- `gita shell repo1 mkdir docs` create a new directory `docs` in repo1
+- `gita shell repo1 "mkdir docs"` create a new directory `docs` in repo1
+
+Note that shell commands containing spaces must be wrapped by quotes to be correctly interpreted.
 
 ## <a name='custom'></a> Customization
 

--- a/gita/__main__.py
+++ b/gita/__main__.py
@@ -252,7 +252,7 @@ def f_shell(args):
     cmds = args.man[i:]
     for name, path in repos.items():
         # TODO: pull this out as a function
-        got = subprocess.run(cmds, cwd=path, check=True,
+        got = subprocess.run(cmds, cwd=path, check=True, shell=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT)
         print(utils.format_output(got.stdout.decode(), name))

--- a/gita/__main__.py
+++ b/gita/__main__.py
@@ -249,7 +249,7 @@ def f_shell(args):
                 for r in groups[k]:
                     chosen[r] = repos[r]
         repos = chosen
-    cmds = args.man[i:]
+    cmds = ' '.join(args.man[i:])  # join the shell command into a single string
     for name, path in repos.items():
         # TODO: pull this out as a function
         got = subprocess.run(cmds, cwd=path, check=True, shell=True,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -170,7 +170,7 @@ def test_shell(mock_run, _, input):
     args = ['shell', 'repo7'] + shlex.split(input)
     __main__.main(args)
     expected_cmds = shlex.split(input)
-    mock_run.assert_called_once_with(expected_cmds, cwd='path7', check=True, stderr=-2, stdout=-1)
+    mock_run.assert_called_once_with(expected_cmds, cwd='path7', check=True, shell=True, stderr=-2, stdout=-1)
 
 
 class TestContext:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -167,9 +167,9 @@ def test_superman(mock_run, _, input):
 @patch('subprocess.run')
 def test_shell(mock_run, _, input):
     mock_run.reset_mock()
-    args = ['shell', 'repo7'] + shlex.split(input)
+    args = ['shell', 'repo7', input]
     __main__.main(args)
-    expected_cmds = shlex.split(input)
+    expected_cmds = input
     mock_run.assert_called_once_with(expected_cmds, cwd='path7', check=True, shell=True, stderr=-2, stdout=-1)
 
 


### PR DESCRIPTION
This PR addresses an issue mentioned in #114, where more complex shell commands such as `git describe --abbrev=0 --tags | xargs git checkout` cannot be executed. This PR adds the `shell=True` argument to `subprocess.run` so that the entire command as a string gets passed to the shell. Note that a side effect of this is that commands containing spaces must be wrapped by quotes, but this is necessary regardless since the shell expansion features must be escaped somehow.

I have also updated the tests and the README to reflect this change.