### PR TITLE
Display tags under `gita ll`

### DIFF
--- a/gita/info.py
+++ b/gita/info.py
@@ -106,7 +106,8 @@ def get_path(path):
 
 
 def get_head(path: str) -> str:
-    result = subprocess.run('git rev-parse --abbrev-ref HEAD'.split(),
+    result = subprocess.run('git symbolic-ref -q --short HEAD || git describe --tags --exact-match',
+                            shell=True,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.DEVNULL,
                             universal_newlines=True,


### PR DESCRIPTION
Closes #117. The git command is taken from [this answer](https://stackoverflow.com/a/18660163). Again since this is a shell script I had to set `shell=True` here and also get rid of the `.split()`.

There are two things I noticed:
- the colour for tags when running `gita ll` is white, I'm guessing because it didn't fit any of the other categories? Just want to check that this is the desired behaviour
- the "info" column does not have fixed width, so the table is not well-aligned. Given that this is implemented as an iterator, I'm not sure how to best do this. If you can suggest an implementation I can throw that in this PR, otherwise it could also be a separate development