### PR TITLE
fix repo name when duplicate exists

### DIFF
--- a/gita/utils.py
+++ b/gita/utils.py
@@ -19,6 +19,7 @@ def is_relative_to(kid: str, parent: str) -> bool:
     """
     Both the `kid` and `parent` should be absolute path
     """
+    # Note that os.path.commonpath has no trailing /
     return parent == os.path.commonpath((kid, parent))
 
 
@@ -195,7 +196,8 @@ def _make_name(path: str, repos: Dict[str, Dict[str, str]],
     """
     name = os.path.basename(os.path.normpath(path))
     if name in repos or name_counts[name] > 1:
-        par_name = os.path.basename(os.path.dirname(os.path.dirname(path)))
+        # path has no trailing /
+        par_name = os.path.basename(os.path.dirname(path))
         return os.path.join(par_name, name)
     return name
 

--- a/gita/utils.py
+++ b/gita/utils.py
@@ -195,7 +195,7 @@ def _make_name(path: str, repos: Dict[str, Dict[str, str]],
     """
     name = os.path.basename(os.path.normpath(path))
     if name in repos or name_counts[name] > 1:
-        par_name = os.path.basename(os.path.dirname(path))
+        par_name = os.path.basename(os.path.dirname(os.path.dirname(path)))
         return os.path.join(par_name, name)
     return name
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', encoding='utf-8') as f:
 setup(
     name='gita',
     packages=['gita'],
-    version='0.15.3',
+    version='0.15.4',
     license='MIT',
     description='Manage multiple git repos with sanity',
     long_description=long_description,


### PR DESCRIPTION
fix #178 

When name clash happens in adding new repos, the solution is to add the parent directory's name in the repo name. However, it was implemented incorrectly: the repo name is reused as parent dir name, thus name clash still occur