### PR TITLE
Print gita shell command output without waiting for command completion

### DIFF
--- a/gita/__main__.py
+++ b/gita/__main__.py
@@ -350,10 +350,15 @@ def f_shell(args):
     cmds = ' '.join(cmds)  # join the shell command into a single string
     for name, prop in repos.items():
         # TODO: pull this out as a function
-        got = subprocess.run(cmds, cwd=prop['path'], shell=True,
+        p = subprocess.Popen(cmds, cwd=prop['path'], shell=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT)
-        print(utils.format_output(got.stdout.decode(), name))
+        with p.stdout:
+            for line in iter(p.stdout.readline, b''): 
+                print(utils.format_output(line.decode(), name), end='')
+        returncode = p.wait()
+        if returncode != 0:
+            raise subprocess.CalledProcessError(returncode, cmds)
 
 
 def f_super(args):


### PR DESCRIPTION
Previously, gita shell was waiting for the command to complete, then it prints its output. When a gita shell command takes a long time to complete, this means it's not possible to monitor the progress of the command.

This PR adds the ability to print output while the command is executing. 
