### PR TITLE
feat(common): env variable for config at project level

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ If more than one repos are specified, the `git` command runs asynchronously,
 with the exception of `log`, `difftool` and `mergetool`,
 which require non-trivial user input.
 
-Repo configuration is saved in `$XDG_CONFIG_HOME/gita/repos.csv`
-(most likely `~/.config/gita/repos.csv`).
+Repo configuration global is saved in `$XDG_CONFIG_HOME/gita/repos.csv`
+(most likely `~/.config/gita/repos.csv`) or if you prefered at project configuration add environment variable `GITA_PROJECT_HOME`.
 
 ## Installation
 

--- a/gita/common.py
+++ b/gita/common.py
@@ -2,7 +2,7 @@ import os
 
 
 def get_config_dir() -> str:
-    root = os.environ.get('XDG_CONFIG_HOME') or os.path.join(
+    root = os.environ.get('GITA_PROJECT_HOME') or os.environ.get('XDG_CONFIG_HOME') or os.path.join(
         os.path.expanduser('~'), '.config')
     return os.path.join(root, "gita")
 


### PR DESCRIPTION
Currently there is no way to manage gita config at project level.

For me a project is composed of a several repos.
My PR adds an environment variable `GITA_PROJECT_HOME`

