### PR TITLE
Update CI to recent Python versions

### DIFF
--- a/.github/workflows/nos.yml
+++ b/.github/workflows/nos.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/nos.yml
+++ b/.github/workflows/nos.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependences
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip wheel
         pip install -r requirements.txt
         pip install .
     - name: Pytest

--- a/.github/workflows/nos.yml
+++ b/.github/workflows/nos.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Hi, thanks for the useful tool.

I was running into an issue (#234) with color printing with Python 3.11 and was preparing a PR. I found that the CI doesn't test that version, so this PR adds support for it. In case this gets accepted, I have a follow-up PR that deals with the original issue.

Closes #233