### PR TITLE
Fix color printing for Python 3.11

### DIFF
--- a/gita/info.py
+++ b/gita/info.py
@@ -9,7 +9,7 @@ from typing import Tuple, List, Callable, Dict
 from . import common
 
 
-class Color(str, Enum):
+class Color(Enum):
     """
     Terminal color
     """
@@ -31,6 +31,12 @@ class Color(str, Enum):
     b_cyan = '\x1b[36;1m'
     b_white = '\x1b[37;1m'
     underline = '\x1B[4m'
+
+    # Make f"{Color.foo}" expand to Color.foo.value .
+    #
+    # See https://stackoverflow.com/a/24487545
+    def __str__(self):
+        return f"{self.value}"
 
 
 default_colors = {

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -94,14 +94,14 @@ class TestLsLl:
         out, err = capfd.readouterr()
         assert err == ""
         assert "gita" in out
-        assert info.Color.end in out
+        assert info.Color.end.value in out
 
         # no color on branch name
         __main__.main(["ll", "-C"])
         out, err = capfd.readouterr()
         assert err == ""
         assert "gita" in out
-        assert info.Color.end not in out
+        assert info.Color.end.value not in out
 
         __main__.main(["ls", "gita"])
         out, err = capfd.readouterr()


### PR DESCRIPTION
Fix for Python 3.11 (not sure what changed, but there were some str and format-related changes in the enum module). Since 3.11 using `f"{Color.foo}"` prints `Color.foo` instead of inserting `Color.foo.value`. One solution is to do that everywhere. Here we opt for a minimally invasive fix and add `__str__` to the `info.Color` enum.

Also remove the str mixin, so replace

    class Color(str, Enum)

by

    class Color(Enum)

Not sure what the str mixin was supposed to solve, but the issue above occurs with or without it and the version without passes all tests.

Modify `test_main.py::TestLsLl.test_ll()` to use `Color.foo.value`.

Closes #234