### PR TITLE
add stashed status

### DIFF
--- a/gita/info.py
+++ b/gita/info.py
@@ -170,7 +170,12 @@ def has_stashed(flags: List[str], path) -> bool:
     """
     # FIXME: this doesn't work for repos like worktrees, bare, etc
     p = Path(path) / ".git" / "logs" / "refs" / "stash"
-    return p.is_file()
+    got = False
+    try:
+        got = p.is_file()
+    except Exception:
+        pass
+    return got
 
 
 def get_commit_msg(prop: Dict[str, str]) -> str:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", encoding="utf-8") as f:
 setup(
     name="gita",
     packages=["gita"],
-    version="0.16.6.3",
+    version="0.16.6.4",
     license="MIT",
     description="Manage multiple git repos with sanity",
     long_description=long_description,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -143,7 +143,7 @@ class TestLsLl:
     @patch("gita.info.get_head", return_value="master")
     @patch(
         "gita.info._get_repo_status",
-        return_value=("dirty", "staged", "untracked", "diverged"),
+        return_value=("dirty", "staged", "untracked", "", "diverged"),
     )
     @patch("gita.info.get_commit_msg", return_value="msg")
     @patch("gita.info.get_commit_time", return_value="")


### PR DESCRIPTION
Here we use a shortcut of checking `.git/logs/refs/stash`, which doesn't work for worktree repos, etc