### PR TITLE
Create group if not exists when cloning repo

### DIFF
--- a/gita/__main__.py
+++ b/gita/__main__.py
@@ -89,13 +89,9 @@ def f_add(args: argparse.Namespace):
         gname = args.group
         if gname not in groups:
             print(f"{gname} does not exists, creating it.")
-            gpath = ""
-            if "gpath" in args:
-                gpath = args.gpath
             utils.write_to_groups_file(
-                {gname: {"repos": sorted(new_repos), "path": gpath}}, "a+"
+                {gname: {"repos": sorted(new_repos), "path": args.gpath}}, "a+"
             )
-            groups = utils.get_groups()
         else:
             gname_repos = set(groups[gname]["repos"])
             gname_repos.update(new_repos)
@@ -234,7 +230,8 @@ def f_clone(args: argparse.Namespace):
         ]
         args.recursive = args.auto_group = args.bare = args.skip_submodule = False
         args.group = group_name
-        args.group_path = prop.get("path", "")
+        if "gpath" not in args:
+            args.gpath = ""
         f_add(args)
 
     return

--- a/gita/__main__.py
+++ b/gita/__main__.py
@@ -185,7 +185,7 @@ def f_clone(args: argparse.Namespace):
 
     path = args.directory or Path.cwd()
 
-    current_repos_path = [r["path"] for r in utils.get_repos(file_only=True).values()]
+    current_repos_path = {r["path"] for r in utils.get_repos(file_only=True).values()}
     if not args.from_file:
         subprocess.run(["git", "clone", args.clonee], cwd=path)
         # add the cloned repo to gita; group is also supported

--- a/gita/__main__.py
+++ b/gita/__main__.py
@@ -574,7 +574,6 @@ def main(argv=None):
     xgroup.add_argument(
         "-g",
         "--group",
-        # choices=utils.get_groups(),  # TODO remove this and create group if does not exists
         help="If set, add repo to the specified group after cloning, otherwise add to gita without group. "
         "If group does not exists, create it.",
     )

--- a/gita/__main__.py
+++ b/gita/__main__.py
@@ -185,7 +185,7 @@ def f_clone(args: argparse.Namespace):
 
     path = args.directory or Path.cwd()
 
-    current_repos_path = {r["path"] for r in utils.get_repos(file_only=True).values()}
+    current_repos_path = {r["path"] for r in utils.get_repos(skip_validation=True).values()}
     if not args.from_file:
         subprocess.run(["git", "clone", args.clonee], cwd=path)
         # add the cloned repo to gita; group is also supported

--- a/gita/__main__.py
+++ b/gita/__main__.py
@@ -207,7 +207,7 @@ def f_clone(args: argparse.Namespace):
     git_version = utils.get_git_version()
     clone_branch = False
     if not args.no_branch:
-        if git_version and git_version >= GIT_MIN_VERSION_FOR_SINGLE_BRANCH_CLONING:
+        if (git_version and git_version >= GIT_MIN_VERSION_FOR_SINGLE_BRANCH_CLONING) or args.force_branch:
             clone_branch = True
         else:
             print(f"Git version {git_version} < {GIT_MIN_VERSION_FOR_SINGLE_BRANCH_CLONING}, not cloning by branch.")
@@ -586,12 +586,18 @@ def main(argv=None):
         action="store_true",
         help="If set, show command without execution",
     )
-    p_clone.add_argument(
+    p_clone.add_argument("--path", dest="gpath", type=_path_name, metavar="group-path",)
+    p_clone_branch_group = p_clone.add_mutually_exclusive_group()
+    p_clone_branch_group.add_argument(
         "--no-branch",
         action="store_true",
         help="If set, don't clone using branch from file.",
     )
-    p_clone.add_argument("--path", dest="gpath", type=_path_name, metavar="group-path",)
+    p_clone_branch_group.add_argument(
+        "--force-branch",
+        action="store_true",
+        help=f"If set, force cloning by branch even if git version is prior to {GIT_MIN_VERSION_FOR_SINGLE_BRANCH_CLONING}.",
+    )
     xgroup = p_clone.add_mutually_exclusive_group()
     xgroup.add_argument(
         "-g",

--- a/gita/__main__.py
+++ b/gita/__main__.py
@@ -199,7 +199,7 @@ def f_clone(args: argparse.Namespace):
         f_add(args)
         return
 
-    repos, groups = io.parse_clone_config(args.clonee)
+    repos_to_clone, groups_to_clone = io.parse_clone_config(args.clonee)
 
     # Check git version for cloning with branch
     git_version = utils.get_git_version()
@@ -211,7 +211,7 @@ def f_clone(args: argparse.Namespace):
             print(f"Git version {git_version} < {GIT_MIN_VERSION_FOR_SINGLE_BRANCH_CLONING}, not cloning by branch.")
 
     clone_tasks = []
-    for repo_name, prop in repos.items():
+    for repo_name, prop in repos_to_clone.items():
         git_cmd = ["git", "clone", prop["url"]]
 
         if clone_branch:
@@ -225,11 +225,11 @@ def f_clone(args: argparse.Namespace):
     utils.exec_async_tasks(clone_tasks)
 
     # add repo to gita repos, not adding already existing paths
-    new_repos = {name: prop for name, prop in repos.items() if prop["path"] not in current_repos_path}
+    new_repos = {name: prop for name, prop in repos_to_clone.items() if prop["path"] not in current_repos_path}
     utils.write_to_repo_file(new_repos, "a+")
 
     # add repo to gita groups, ig group already exists, add new repo to it if there is.
-    for gname, prop in groups.items():
+    for gname, prop in groups_to_clone.items():
         args.group_cmd = "add"
         args.gname = gname
         args.to_group = prop["repos"]

--- a/gita/__main__.py
+++ b/gita/__main__.py
@@ -197,7 +197,6 @@ def f_clone(args: argparse.Namespace):
         f_add(args)
         return
 
-    # TODO: add repos to group too
     repos, groups = io.parse_clone_config(args.clonee)
 
     git_version = utils.get_git_version()
@@ -223,15 +222,13 @@ def f_clone(args: argparse.Namespace):
     utils.exec_async_tasks(clone_tasks)
 
     # add repo to gita
-    for group_name, prop in groups.items():
+    for prop in groups.values():
         args.paths = [
             os.path.join(path, repo.split("/")[-1].split(".")[0])
             for repo in prop.get("repos", [])
         ]
         args.recursive = args.auto_group = args.bare = args.skip_submodule = False
-        args.group = group_name
-        if "gpath" not in args:
-            args.gpath = ""
+        args.gpath = prop.get("path", "")
         f_add(args)
 
     return
@@ -514,9 +511,9 @@ def main(argv=None):
     p_add.add_argument(
         "-g",
         "--group",
-        choices=utils.get_groups(),
-        help="add repo(s) to the specified group",
+        help="add repo(s) to the specified group. If group does not exists, create it.",
     )
+    p_add.add_argument("--group-path", dest="gpath", type=_path_name)
     p_add.add_argument(
         "-s", "--skip-submodule", action="store_true", help="skip submodule repo(s)"
     )
@@ -583,7 +580,6 @@ def main(argv=None):
         action="store_true",
         help="If set, show command without execution",
     )
-    p_clone.add_argument("--path", dest="gpath", type=_path_name, metavar="group-path",)
     p_clone_branch_group = p_clone.add_mutually_exclusive_group()
     p_clone_branch_group.add_argument(
         "--no-branch",

--- a/gita/__main__.py
+++ b/gita/__main__.py
@@ -211,6 +211,16 @@ def f_clone(args: argparse.Namespace):
             for repo_name, r in repos.items()
         )
 
+    # add repo to gita
+    for group_name, prop in groups.items():
+        args.paths = [os.path.join(path, repo.split("/")[-1].split(".")[0]) for repo in prop.get("repos", [])]
+        args.recursive = args.auto_group = args.bare = args.skip_submodule = False
+        args.group = group_name
+        args.group_path = prop.get("path", "")
+        f_add(args)
+
+    return
+
 
 def f_freeze(args):
     """

--- a/gita/io.py
+++ b/gita/io.py
@@ -13,7 +13,7 @@ def parse_clone_config(fname: str) -> Tuple:
     if os.path.isfile(fname) and os.stat(fname).st_size > 0:
         with open(fname) as f:
             rows = csv.DictReader(
-                f, ["url", "name", "path", "type", "flags"], restval=""
+                f, ["url", "name", "path", "type", "flags", "branch"], restval=""
             )  # it's actually a reader
             for r in rows:
                 if r["url"]:
@@ -22,6 +22,7 @@ def parse_clone_config(fname: str) -> Tuple:
                         "type": r["type"],
                         "flags": r["flags"].split(),
                         "url": r["url"],
+                        "branch": r["branch"],
                     }
                 else:
                     groups[r["name"]] = {

--- a/gita/utils.py
+++ b/gita/utils.py
@@ -42,12 +42,12 @@ def get_relative_path(kid: os.PathLike, parent: str) -> Union[List[str], None]:
 
 
 @lru_cache()
-def get_repos(file_only: bool = False) -> Dict[str, Dict[str, str]]:
+def get_repos(skip_validation: bool = False) -> Dict[str, Dict[str, str]]:
     """
     Return a `dict` of repo name to repo absolute path and repo type
 
     Parameters:
-    file_only (bool): Returns repo in config even if their path do not exists.
+    skip_validation (bool): Returns repos in config even if their path do not exists.
     """
     path_file = common.get_config_fname("repos.csv")
     repos = {}
@@ -57,7 +57,7 @@ def get_repos(file_only: bool = False) -> Dict[str, Dict[str, str]]:
                 f, ["path", "name", "type", "flags"], restval=""
             )  # it's actually a reader
             for r in rows:
-                if file_only or is_git(r["path"], include_bare=True):
+                if skip_validation or is_git(r["path"], include_bare=True):
                     repos[r["name"]] = {
                         "path": r["path"],
                         "type": r["type"],

--- a/gita/utils.py
+++ b/gita/utils.py
@@ -56,7 +56,6 @@ def get_repos(file_only: bool = False) -> Dict[str, Dict[str, str]]:
             rows = csv.DictReader(
                 f, ["path", "name", "type", "flags"], restval=""
             )  # it's actually a reader
-            repos = {}
             for r in rows:
                 if file_only or is_git(r["path"], include_bare=True):
                     repos[r["name"]] = {
@@ -64,7 +63,6 @@ def get_repos(file_only: bool = False) -> Dict[str, Dict[str, str]]:
                         "type": r["type"],
                         "flags": r["flags"].split(),
                     }
-                    continue
     return repos
 
 
@@ -242,7 +240,7 @@ def write_to_repo_file(repos: Dict[str, Dict[str, str]], mode: str):
     """
     # The 3rd column is repo type; unused field
     data = [
-        (prop["path"], name, "", " ".join(prop["flags"]))
+        (prop["path"], name, prop.get("type", ""), " ".join(prop["flags"]))
         for name, prop in repos.items()
     ]
     fname = common.get_config_fname("repos.csv")

--- a/gita/utils.py
+++ b/gita/utils.py
@@ -11,13 +11,13 @@ from typing import List, Dict, Coroutine, Union, Tuple
 from collections import Counter, defaultdict
 from concurrent.futures import ThreadPoolExecutor
 import multiprocessing
+from packaging.version import Version
 
 from . import info
 from . import common
 
 
 MAX_INT = sys.maxsize
-
 
 def get_relative_path(kid: os.PathLike, parent: str) -> Union[List[str], None]:
     """
@@ -503,3 +503,21 @@ def parse_repos_and_rest(
         # if not set here, all repos are chosen
         repos = chosen
     return repos, input[i:]
+
+def get_git_version() -> Version:
+    """Get git version using subprocess and packaging.version.Version.
+
+    Using Version to avoid such issue:
+
+    In [13]: b"1.7.9" > b"1.7.10"
+    Out[13]: True
+
+    In [14]: Version(b"1.7.9".decode()) > Version("1.7.10")
+    Out[14]: False
+    """
+    try:
+        return Version(subprocess.check_output("git --version", shell=True).split()[-1].decode())
+    except Exception:
+        # NOTE Global exception handling is bad, but it may be worse to account for
+        # every possible failure
+        return None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -198,7 +198,7 @@ def test_clone_with_url(mock_run):
 @patch(
     "gita.io.parse_clone_config",
     return_value=(
-        {"repo": {"url": "git@github.com:user/repo.git", "path": "/a/repo"}},
+        {"repo": {"url": "git@github.com:user/repo.git", "path": "/a/repo", "flags": []}},
         {},
     ),
 )
@@ -222,7 +222,7 @@ def test_clone_with_config_file(*_):
 @patch(
     "gita.io.parse_clone_config",
     return_value=(
-        {"repo": {"url": "git@github.com:user/repo.git", "path": "/a/repo"}},
+        {"repo": {"url": "git@github.com:user/repo.git", "path": "/a/repo", "flags": []}},
         {},
     ),
 )


### PR DESCRIPTION
# Resolves #260 & #271 + add cloning by branch

Create the group when using `gita clone <repo> -g <group_name>`.

Also, I have added the argument `--path` for the group path to the  `p_clone` parser, but I don't understand what this `group_path` is used for. I have not found anything in the README, maybe adding some information on it could be useful ?

## On cloning by branch

I have tried to implement it, but it may need some discussion on the implementation.

1. I have added the **current** branch of each repo when doing a `gita freeze`
2. When using `gita clone -f <freeze_file>` it does one of the following :
    2a. If the option `--no-branch` is used, it does not try to clone by branch
    2b. If the git version is prior to 1.7.10 and the option `--force-branch` is not used, it does not try to clone by branch, as the git option `--single-branch` is not yet available, and cloning by branch wil in fact clone every branch and may result in unwanted data fetching (see https://stackoverflow.com/a/1911126)
   2c. If none of the above happens, it will clone by branch using the branch name in the freeze_file generated by `gita freeze`