### PR TITLE
FIX: Require packaging install in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author_email="zhou.dong@gmail.com",
     entry_points={"console_scripts": ["gita = gita.__main__:main"]},
     python_requires=">=3.8",
-    install_requires=["argcomplete"],
+    install_requires=["argcomplete", "packaging"],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Fixes #297

Installation is of 0.16.8 is broken as packaging is not a part of the standard library but not listed as a dependency in `setup.py`.

To confirm the fix, clone gita locally and run `pipx run --no-cache <local repo path>` before and after this commit.