### PR TITLE
fix: add `uninstall` to Makefile phony targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dist test install clean twine auto-completion
+.PHONY: dist test install uninstall clean twine auto-completion
 
 install:
 	pip3 install -e .


### PR DESCRIPTION
- Added `uninstall` to the `.PHONY` targets in the `Makefile` to clarify it as a phony target.


Relevant PR: #287